### PR TITLE
Work in progress: update Django and Haystack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ data/*
 settings.py
 nohup.out
 pip-log.txt
+*.DS_Store
+node_modules
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ settings.py
 nohup.out
 pip-log.txt
 *.DS_Store
-node_modules
-

--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,10 @@
-DocuDig_Dat
+DocuDig
 +++++++
 
-<a href="https://github.com/yourcelf/docudig">DocuDig</a> is a Django application for rich faceted browsing and searching of
+DocuDig is a Django application for rich faceted browsing and searching of
 structured documents.  It began its life as a search application for the
 WikiLeaks war log releases, but has evolved to a general purpose structured
 document browsing and searching tool.
-
-<a href="https://github.com/maxogden/dat">Dat</a> is a tool for sharing and versioning tabular data.
-This DocuDig_Dat branch adds capability to upload documents to DocuDig using Dat.
-Dat is an alternative to git which better supports:
-
-* real time data (sensors, social media, geolocation)
-* transforming data (tracking updates in several formats)
-* data filtering/subsets
 
 *Features*
 
@@ -262,6 +254,6 @@ restarting Solr, the following management command will rebuild the index::
 License
 -------
 
-This branch is made available under the GPLv3 license.
+Granted to the public domain.  If you need other licensing, please file an
+issue.
 
-Original DocuDig is granted to the public domain.

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,18 @@
-DocuDig
+DocuDig_Dat
 +++++++
 
-DocuDig is a Django application for rich faceted browsing and searching of
+<a href="https://github.com/yourcelf/docudig">DocuDig</a> is a Django application for rich faceted browsing and searching of
 structured documents.  It began its life as a search application for the
 WikiLeaks war log releases, but has evolved to a general purpose structured
 document browsing and searching tool.
+
+<a href="https://github.com/maxogden/dat">Dat</a> is a tool for sharing and versioning tabular data.
+This DocuDig_Dat branch adds capability to upload documents to DocuDig using Dat.
+Dat is an alternative to git which better supports:
+
+* real time data (sensors, social media, geolocation)
+* transforming data (tracking updates in several formats)
+* data filtering/subsets
 
 *Features*
 
@@ -254,5 +262,6 @@ restarting Solr, the following management command will rebuild the index::
 License
 -------
 
-Granted to the public domain.  If you need other licensing, please file an
-issue.
+This branch is made available under the GPLv3 license.
+
+Original DocuDig is granted to the public domain.

--- a/default_settings.py
+++ b/default_settings.py
@@ -118,8 +118,16 @@ if len(document_fields) != 1:
     raise Exception("One and only one field must be labeled with 'document=True'")
 DOCUMENT_FIELD = document_fields[0]
 
-HAYSTACK_SITECONF = "search_sites"
-HAYSTACK_SEARCH_ENGINE = 'solr'
-HAYSTACK_SOLR_URL = "http://127.0.0.1:8983/solr"
+HAYSTACK_CONNECTIONS = {
+  'default': {
+        'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
+        'URL': 'http://localhost:8983/solr',
+        'TIMEOUT': 60 * 5,
+        'INCLUDE_SPELLING': True,
+        'BATCH_SIZE': 100,
+        'EXCLUDED_INDEXES': []
+   }
+}
+HAYSTACK_SOLR_URL = "http://localhost:8983/solr"
 
 CACHE_MIDDLEWARE_SECONDS = 10 * 60

--- a/dig/search_indexes.py
+++ b/dig/search_indexes.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 
 from haystack import indexes, fields
-from haystack import site
 
 from dig.models import Document
 
@@ -31,13 +30,11 @@ for name, field in settings.ALL_FIELDS.items():
         raise Exception("Unrecognized search index field type '%s'." % field['type'])
     index_fields[field['name']] = index_field
 
-# Override metaclass to let us specify fields non-declaratively.
+
 class DocumentMetaclass(indexes.DeclarativeMetaclass):
     def __new__(cls, name, bases, attrs):
-        return super(DocumentMetaclass, cls).__new__(cls, name, 
+        return super(DocumentMetaclass, cls).__new__(cls, name,
                 bases, index_fields)
 
 class DocumentIndex(indexes.SearchIndex):
     __metaclass__ = DocumentMetaclass
-
-site.register(Document, DocumentIndex)

--- a/dig/templates/dig/_constraints.html
+++ b/dig/templates/dig/_constraints.html
@@ -7,7 +7,7 @@ Searching for:
     {% for constraint in constraints %}
         <div class='constraint'>
             <span class='label'>{{ constraint.display }}: {{ constraint.value }}</span>
-            <a href='{% url dig.search %}{% if constraint.remove_link or cur_sort_qstring %}?{% endif %}{% if constraint.remove_link %}{{ constraint.remove_link }}&{% endif %}{{ cur_sort_qstring }}' 
+            <a href='{% url "dig.search" %}{% if constraint.remove_link or cur_sort_qstring %}?{% endif %}{% if constraint.remove_link %}{{ constraint.remove_link }}&{% endif %}{{ cur_sort_qstring }}' 
                title='Click to remove this constraint'
                style='float: left;'
              ><span class='ui-icon ui-icon-circle-close'></span></a>

--- a/dig/templates/dig/_facets.html
+++ b/dig/templates/dig/_facets.html
@@ -28,7 +28,7 @@
         $(selector).html(facets);
     }
 </script>
-<form method='GET' action='{% url dig.search %}' onsubmit='clean_get(this)'>
+<form method='GET' action='{% url "dig.search" %}' onsubmit='clean_get(this)'>
 {% for constraint in constraints %}
     {% if constraint.type == 'text' %}
         <input type='hidden' value='{{ constraint.value }}' name='{{ constraint.key }}' />
@@ -60,7 +60,7 @@
         {% endif %}
         <ul id='facets_{{ name }}'>
             {% for opt in choice.choices %}
-            <li><a href='{% url dig.search %}?{% if querystr %}{{ querystr }}&{% endif %}{% if cur_sort %}{{ cur_sort_qstring }}&{% endif %}{{ name }}={{ opt.0|urlencode }}'>{{ opt.0 }}</a> ({{ opt.1 }})</li>
+            <li><a href='{% url "dig.search" %}?{% if querystr %}{{ querystr }}&{% endif %}{% if cur_sort %}{{ cur_sort_qstring }}&{% endif %}{{ name }}={{ opt.0|urlencode }}'>{{ opt.0 }}</a> ({{ opt.1 }})</li>
             {% endfor %}
         </ul>
     {% endif %}

--- a/dig/views.py
+++ b/dig/views.py
@@ -166,7 +166,7 @@ def _parse_facets(qd):
                     'display': field['display_name'],
                 })
         elif field['faceted']:
-            sqs = sqs.raw_params(**{
+            sqs = sqs.raw_search("", **{
                 'f.%s_exact.facet.limit' % field['name']: field['facet_limit']
              })
             if field['type'] == 'date':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-django >= 1.2.3
+django == 1.5.5
 
-# Use a version of django-haystack patched to support raw query params (Needed
-# to set facet.limit)
--e git://github.com/localbase/django-haystack.git#egg=django-haystack
+django-haystack
 pysolr
 psycopg2


### PR DESCRIPTION
Hi - this isn't a complete pull request, but I hope you can help get it the last mile.

DocuDig uses an old version of Django and a no-longer-available branch of Haystack which was at https://github.com/localbase/django-haystack

I'm trying to update it to work with current versions of Django, Haystack, and Solr. There are three main issues, all with how Haystack talks to Solr
- Haystack is making a schema.xml without custom fields and only has id. I think this is a search_indexes.py issue - https://django-haystack.readthedocs.org/en/latest/migration_from_1_to_2.html#indexes
- Haystack is making schema.xml with references stopwords.txt and stopwords_en.txt, which I've been changing by hand to lang/stopwords_en.txt
- I don't see any documents going into Solr, but it's likely because the schema.xml doesn't match (this is the error that I get when I use PySolr directly)

If I can get this running, I'm going to try to get it so that someone could use version control like git or dat to update the data.
